### PR TITLE
feat(renaming): move renaming to a separate thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ As is visible above, all files that were subject to renaming (eveything other th
 
 ## Changelog
 
+### 2025-10-26
+1. [Threading] Move the file renaming process to a background thread using `QThreadPool` and `QRunnable` (`Worker` class)
+2. [UI] Disable UI controls (buttons, checkboxes) during renaming to prevent user interaction while the operation is in progress
+3. [UI] Add progress reporting: the "Rename files" button now displays percentage completion during renaming
+4. [UI] Update logic to re-enable controls and show a success message when renaming completes
+5. [Other] Rename old `rename_files` function to `rename_files_from_file_map`, and create new `rename_files` which calls both `get_renaming_map` and `rename_files_from_map`, and can be delegated to a separate thread
+6. [Other] Add models (`Protocol` subclasses) for `Worker` and `Signal` appropriately named `IWorker` and `ISignal`
+
 ### 2025-02-04
 1. [Fix] Fix issue not allowing to choose folders on Windows 11
 2. [UI] Only allow to choose directories/folders in the file dialog
@@ -110,6 +118,8 @@ As is visible above, all files that were subject to renaming (eveything other th
 2. By default apply the padding automatically based on the number of files in the choosen directory
 
 ## Features to add
+- Show a dialog with progress of the renaming
+- Show logs in the application window (e.g., which file got renamed, which already had the correct name etc.)
 - Be able to select specific files to renames (instead of whole directories) - could be with a switch (radio button) to let user decide whether they want whole directory or just some files
 - Add a switch (checkbox maybe or iPhone-like switch) to have the number padding only automatic (disable user input) or forced by user (still the default value will be automatic)
 - Add a loader (based on the number of files already renamed vs remaining)
@@ -117,7 +127,7 @@ As is visible above, all files that were subject to renaming (eveything other th
 - Add a separate toggle to also rename directories (eg. smth like `isDir` check)
 
 ## Known bugs
-- None
+- After renaming, changing the extension selection does not enable the "Rename" button (it should, since both modifying the length of padding and "New name" do it)
 
 ## Fixes to do
 - Reset the "Rename files" button if the input name or extensions selection changes without having to re-choose a directory again
@@ -128,3 +138,4 @@ As is visible above, all files that were subject to renaming (eveything other th
 - Store logs in a file
 
 ## Other chores to do
+- Make sure all variables follow the same naming convention (e.g., all buttons are suffixed with `_btn`)

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,4 +1,8 @@
-from typing import Protocol
+from typing import (
+    Any,
+    Callable,
+    Protocol
+)
 from re import Pattern
 
 
@@ -47,4 +51,46 @@ class IRenamer(Protocol):
             directory: str,
             files_map: dict[str, str]
     ) -> None:
+        ...
+
+
+class IWorker(Protocol):
+    """Protocol class for a worker thread used by the application.
+
+    Used for static type checking without having
+    to import the actual `Worker` class.
+
+    Provides a blueprint for creating other workers
+    to be used plug&play in the app.
+    """
+
+    def __init__(self, fn: Callable, *args, **kwargs) -> None:
+        """Initialise the worker thread.
+
+        Args:
+            fn (Callable): The function to be executed.
+            args: The arguments to be passed to `fn`.
+            kwargs: The keyword arguments to be passed to `fn`.
+        """
+        ...
+
+    def run(self) -> None:
+        """Run the runner function with passed args, kwargs."""
+        ...
+
+
+class ISignal(Protocol):
+    """Protocol class for a signal used by PySide/PyQt.
+
+    Used for static type checking without having
+    to import the actual `Signal` class.
+    """
+
+    def emit(self, value: Any) -> None:
+        """Emit the signal.
+
+        Args:
+            value (Any): The value to be emitted
+                by the signal.
+        """
         ...

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -1,0 +1,73 @@
+import sys
+from typing import Callable
+import traceback
+
+from PySide6.QtCore import (
+    Signal,
+    Slot,
+    QRunnable,
+    QObject
+)
+
+
+class WorkerSignals(QObject):
+    """Represents signals from a running worker thread.
+
+    Based on https://www.pythonguis.com/tutorials/multithreading-pyside6-applications-qthreadpool/
+
+    finished
+        No data
+
+    error
+        tuple (exctype, value, traceback.format_exc())
+
+    result
+        object data returned from processing, anything
+
+    progress
+        float indicating task progress
+    """
+
+    finished = Signal()
+    error = Signal(tuple)
+    result = Signal(object)
+    progress = Signal(float)
+
+
+class Worker(QRunnable):
+    """Represents a worker thread.
+
+    Inherits from QRunnable to handle thread setup, signals and clean-up.
+    """
+
+    def __init__(self, fn: Callable, *args, **kwargs) -> None:
+        """Initialise the worker thread.
+
+        Args:
+            fn (Callable): The function to be executed.
+            args: The arguments to be passed to `fn`.
+            kwargs: The keyword arguments to be passed to `fn`.
+        """
+        super().__init__()
+        self.fn: Callable = fn
+        self.args = args
+        self.kwargs = kwargs
+        self.signals = WorkerSignals()
+        self.kwargs["progress_callback"] = self.signals.progress
+
+    @Slot()
+    def run(self) -> None:
+        """Run the runner function with passed args, kwargs."""
+
+        try:
+            result = self.fn(*self.args, **self.kwargs)
+
+        except Exception:
+            traceback.print_exc()
+            exctype, value = sys.exc_info()[:2]
+            self.signals.error.emit((exctype, value, traceback.format_exc()))
+
+        else:
+            self.signals.result.emit(result)
+
+        self.signals.finished.emit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "LGPL-3.0-only"
 
 [tool.poetry]
 name = "batch-file-renamer"
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 packages = [
     { include = "app" }


### PR DESCRIPTION
Move the file renaming process to a background thread using `QThreadPool` and `QRunnable` (`Worker` class).

Disable UI controls (buttons, checkboxes) during renaming to prevent user interaction while the operation is in progress.

Add progress reporting: the "Rename files" button now displays percentage completion during renaming.

Update logic to re-enable controls and show a success message when renaming completes.

Rename old `rename_files` function to `rename_files_from_file_map`, and create new `rename_files` which calls both `get_renaming_map` and `rename_files_from_map`, and can be delegated to a separate thread.

Add models (`Protocol` subclasses) for `Worker` and `Signal` classes appropriately named `IWorker` and `ISignal`.